### PR TITLE
Fix displayed bound wallet

### DIFF
--- a/packages/nextjs/app/components/BindWalletButton.tsx
+++ b/packages/nextjs/app/components/BindWalletButton.tsx
@@ -8,7 +8,7 @@ import { CheckCircleIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outl
 
 export function BindWalletButton() {
   const { address, isConnected } = useAccount();
-  const { bind, isLoading, isFetching, success, error, displayPubKey } = useBindWallet();
+  const { bind, isLoading, isFetching, success, error, keyRes } = useBindWallet();
 
   if (!isConnected || !address) return null;
 
@@ -16,11 +16,11 @@ export function BindWalletButton() {
     return <p className="text-yellow-300">Checking if your wallet is bound...</p>;
   }
 
-  if (success && displayPubKey?.isBound) {
+  if (success && keyRes?.isBound) {
     return (
       <div>
         <p className="text-green-400 font-semibold">Wallet bound successfully ✅</p>
-        <WalletAddress address={displayPubKey.address} />
+        <WalletAddress address={keyRes.flowEDUAddress} />
       </div>
     );
   }
@@ -34,7 +34,7 @@ export function BindWalletButton() {
         disabled={isLoading}
         className="bg-yellow-300 text-black px-4 py-2 rounded disabled:opacity-50"
       >
-        {isLoading ? "Binding..." : success && displayPubKey?.isBound ? "Wallet Bound ✅" : "Bind Wallet"}
+        {isLoading ? "Binding..." : success && keyRes?.isBound ? "Wallet Bound ✅" : "Bind Wallet"}
       </button>
 
       {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/packages/nextjs/app/hooks/useBindWallet.ts
+++ b/packages/nextjs/app/hooks/useBindWallet.ts
@@ -15,18 +15,18 @@ export function useBindWallet() {
 
   // SWR fetch on mount
   const {
-    data: displayPubKey,
+    data: keyRes,
     mutate,
     isLoading: isFetching,
     error: keyResErr,
   } = useSWR<GenerateKeypairResponse>(isConnected && address ? `/api/generate-keypair/${address}` : null, fetcher);
   useEffect(() => {
-    if (displayPubKey?.isBound) setSuccess(true);
-  }, [displayPubKey]);
+    if (keyRes?.isBound) setSuccess(true);
+  }, [keyRes]);
 
   const bind = async () => {
     if (!address) return;
-    if (!displayPubKey) {
+    if (!keyRes) {
       setError(keyResErr?.toString() || "Error retriving bound info");
 
       return;
@@ -34,7 +34,7 @@ export function useBindWallet() {
 
     setError(null);
 
-    const { flowEDUAddress: publicKey, isBound, message } = displayPubKey;
+    const { flowEDUAddress: publicKey, isBound, message } = keyRes;
     if (!message) throw new Error("Binding message not retrieved");
 
     if (isBound) {
@@ -71,6 +71,6 @@ export function useBindWallet() {
     isFetching,
     success,
     error,
-    displayPubKey,
+    keyRes,
   };
 }


### PR DESCRIPTION
- fix: Bound wallet address was erroneously displayed as `address` instead of `flowEDUAdress`

- refactor: rename `displayPubKey` to `keyRes` in `useBindWallet` and `BindWalletButton` components